### PR TITLE
file caching for Windows

### DIFF
--- a/equivariant_attention/from_se3cnn/cache_file.py
+++ b/equivariant_attention/from_se3cnn/cache_file.py
@@ -6,7 +6,7 @@ import pickle
 import gzip
 import os
 import sys
-import fcntl
+import msvcrt
 
 
 class FileSystemMutex:
@@ -24,7 +24,7 @@ class FileSystemMutex:
         if it is already locked, it waits (blocking function)
         '''
         self.handle = open(self.filename, 'w')
-        fcntl.lockf(self.handle, fcntl.LOCK_EX)
+        msvcrt.locking(self.handle, msvcrt.LK_LOCK, 1)
         self.handle.write("{}\n".format(os.getpid()))
         self.handle.flush()
 
@@ -34,7 +34,7 @@ class FileSystemMutex:
         '''
         if self.handle is None:
             raise RuntimeError()
-        fcntl.lockf(self.handle, fcntl.LOCK_UN)
+        msvcrt.locking(self.handle, msvcrt.LK_UNLCK, 1)
         self.handle.close()
         self.handle = None
 

--- a/equivariant_attention/from_se3cnn/cache_file.py
+++ b/equivariant_attention/from_se3cnn/cache_file.py
@@ -6,7 +6,10 @@ import pickle
 import gzip
 import os
 import sys
-import msvcrt
+if sys.platform == 'win32':
+  import msvcrt
+else:
+  import fcntl
 
 
 class FileSystemMutex:
@@ -24,7 +27,10 @@ class FileSystemMutex:
         if it is already locked, it waits (blocking function)
         '''
         self.handle = open(self.filename, 'w')
-        msvcrt.locking(self.handle, msvcrt.LK_LOCK, 1)
+        if sys.platform == 'win32':
+            msvcrt.locking(self._fo.fileno(), msvcrt.LK_LOCK, 1)
+        else:
+            fcntl.lockf(self.handle, fcntl.LOCK_EX)
         self.handle.write("{}\n".format(os.getpid()))
         self.handle.flush()
 
@@ -34,7 +40,10 @@ class FileSystemMutex:
         '''
         if self.handle is None:
             raise RuntimeError()
-        msvcrt.locking(self.handle, msvcrt.LK_UNLCK, 1)
+        if sys.platform == 'win32':
+            msvcrt.locking(self.handle.fileno(), msvcrt.LK_UNLCK, 1)
+        else:
+            fcntl.lockf(self.handle, fcntl.LOCK_UN)
         self.handle.close()
         self.handle = None
 


### PR DESCRIPTION
Support file locking inf `cache_file.py` for both windows and unix systems by checking the `sys.platform` and importing/locking accordingly